### PR TITLE
✨ feat: 포인트 관리자 API 구현

### DIFF
--- a/http/point.http
+++ b/http/point.http
@@ -100,3 +100,55 @@ X-USER-ID: 1
 ### 3.3. 없는 유저 조회 테스트 (예외 발생)
 GET http://localhost:9002/api/points/balance
 X-USER-ID: 99999
+
+
+
+
+
+### 4. 현재 포인트 정책 조회
+GET http://localhost:9002/api/admin/points/policy
+
+### 4.1. 포인트 정책 변경 (update)
+POST http://localhost:9002/api/admin/points/policy
+Content-Type: application/json
+
+{
+  "signupPoint": 10000,
+  "reviewPoint": 5000,
+  "photoPoint": 1000
+}
+
+
+
+
+### 5. 관리자 수동 포인트 지급
+POST http://localhost:9002/api/admin/points/adjustment
+Content-Type: application/json
+
+{
+  "memberId": 1,
+  "amount": 3000,
+  "reason": "배송 지연 보상금"
+}
+
+### 16. 관리자 수동 포인트 차감
+POST http://localhost:9002/api/admin/points/adjustment
+Content-Type: application/json
+X-USER-ID: 999
+
+{
+  "memberId": 1,
+  "amount": -500,
+  "reason": "시스템 오류로 지급된 포인트 회수"
+}
+
+### 17. 관리자 수동 차감 실패 (잔액 부족)
+POST http://localhost:9002/api/admin/points/adjustment
+Content-Type: application/json
+X-USER-ID: 999
+
+{
+  "memberId": 1,
+  "amount": -999999999,
+  "reason": "악성 유저 포인트 차감"
+}

--- a/src/main/java/com/nhnacademy/member_server/controller/PointAdminController.java
+++ b/src/main/java/com/nhnacademy/member_server/controller/PointAdminController.java
@@ -1,0 +1,42 @@
+package com.nhnacademy.member_server.controller;
+
+import com.nhnacademy.member_server.dto.request.PointAdminAdjustmentRequest;
+import com.nhnacademy.member_server.dto.request.PointAdminPolicyRequest;
+import com.nhnacademy.member_server.dto.response.PointAdminPolicyResponse;
+import com.nhnacademy.member_server.dto.response.PointTransactionResponse;
+import com.nhnacademy.member_server.service.PointService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/admin/points")
+@RequiredArgsConstructor
+public class PointAdminController{
+
+    private final PointService pointService;
+
+    @GetMapping("/policy")
+    public ResponseEntity<PointAdminPolicyResponse> getPolicy() {
+
+        return ResponseEntity.ok(pointService.getRecentPolicy());
+    }
+
+    @PostMapping("/policy")
+    public ResponseEntity<Void> updatePolicy(@RequestBody PointAdminPolicyRequest request) {
+        pointService.updatePolicy(request);
+
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/adjustment")
+    public ResponseEntity<PointTransactionResponse> adjustmentMemberPoint(@RequestBody PointAdminAdjustmentRequest request) {
+        Long currentPoint = pointService.adjustmentMemberPoint(request);
+
+        return ResponseEntity.ok(new PointTransactionResponse(request.getMemberId(), currentPoint));
+    }
+}

--- a/src/main/java/com/nhnacademy/member_server/controller/PointAdminController.java
+++ b/src/main/java/com/nhnacademy/member_server/controller/PointAdminController.java
@@ -1,5 +1,6 @@
 package com.nhnacademy.member_server.controller;
 
+import com.nhnacademy.member_server.docs.PointAdminSwagger;
 import com.nhnacademy.member_server.dto.request.PointAdminAdjustmentRequest;
 import com.nhnacademy.member_server.dto.request.PointAdminPolicyRequest;
 import com.nhnacademy.member_server.dto.response.PointAdminPolicyResponse;
@@ -16,16 +17,18 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/admin/points")
 @RequiredArgsConstructor
-public class PointAdminController{
+public class PointAdminController implements PointAdminSwagger {
 
     private final PointService pointService;
 
+    @Override
     @GetMapping("/policy")
     public ResponseEntity<PointAdminPolicyResponse> getPolicy() {
 
         return ResponseEntity.ok(pointService.getRecentPolicy());
     }
 
+    @Override
     @PostMapping("/policy")
     public ResponseEntity<Void> updatePolicy(@RequestBody PointAdminPolicyRequest request) {
         pointService.updatePolicy(request);
@@ -33,6 +36,7 @@ public class PointAdminController{
         return ResponseEntity.ok().build();
     }
 
+    @Override
     @PostMapping("/adjustment")
     public ResponseEntity<PointTransactionResponse> adjustmentMemberPoint(@RequestBody PointAdminAdjustmentRequest request) {
         Long currentPoint = pointService.adjustmentMemberPoint(request);

--- a/src/main/java/com/nhnacademy/member_server/controller/PointController.java
+++ b/src/main/java/com/nhnacademy/member_server/controller/PointController.java
@@ -1,5 +1,6 @@
 package com.nhnacademy.member_server.controller;
 
+import com.nhnacademy.member_server.docs.PointSwagger;
 import com.nhnacademy.member_server.dto.response.PointBalanceResponse;
 import com.nhnacademy.member_server.dto.response.PointHistoryResponse;
 import com.nhnacademy.member_server.service.PointService;
@@ -18,7 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/points")
-public class PointController implements PointSwagger{
+public class PointController implements PointSwagger {
 
     private final PointService pointService;
 

--- a/src/main/java/com/nhnacademy/member_server/controller/PointInternalController.java
+++ b/src/main/java/com/nhnacademy/member_server/controller/PointInternalController.java
@@ -1,5 +1,6 @@
 package com.nhnacademy.member_server.controller;
 
+import com.nhnacademy.member_server.docs.PointInternalSwagger;
 import com.nhnacademy.member_server.dto.request.PointEarnRequest;
 import com.nhnacademy.member_server.dto.request.PointTransactionRequest;
 import com.nhnacademy.member_server.dto.response.PointTransactionResponse;
@@ -14,7 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/internal/points")
-public class PointInternalController implements PointInternalSwagger{
+public class PointInternalController implements PointInternalSwagger {
 
     private final PointService pointService;
 

--- a/src/main/java/com/nhnacademy/member_server/controller/PointPolicyAdminController.java
+++ b/src/main/java/com/nhnacademy/member_server/controller/PointPolicyAdminController.java
@@ -1,9 +1,0 @@
-package com.nhnacademy.member_server.controller;
-
-import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RestController;
-
-@RestController
-@RequiredArgsConstructor
-public class PointPolicyAdminController {
-}

--- a/src/main/java/com/nhnacademy/member_server/docs/PointAdminSwagger.java
+++ b/src/main/java/com/nhnacademy/member_server/docs/PointAdminSwagger.java
@@ -12,7 +12,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 
 @Tag(name = "Point Admin API", description = "관리자용 포인트 정책 및 수동 조정 API")
-public interface PointPolicyAdminSwagger {
+public interface PointAdminSwagger {
 
     @Operation(summary = "포인트 정책 조회", description = "현재 적용 중인 최신 포인트 정책을 조회합니다.")
     @ApiResponses(value = {
@@ -36,5 +36,5 @@ public interface PointPolicyAdminSwagger {
             @ApiResponse(responseCode = "404", description = "존재하지 않는 회원"),
             @ApiResponse(responseCode = "500", description = "서버 내부 오류")
     })
-    ResponseEntity<PointTransactionResponse> manualAdjustment(@RequestBody PointAdminAdjustmentRequest request);
+    ResponseEntity<PointTransactionResponse> adjustmentMemberPoint(@RequestBody PointAdminAdjustmentRequest request);
 }

--- a/src/main/java/com/nhnacademy/member_server/docs/PointInternalSwagger.java
+++ b/src/main/java/com/nhnacademy/member_server/docs/PointInternalSwagger.java
@@ -1,4 +1,4 @@
-package com.nhnacademy.member_server.controller;
+package com.nhnacademy.member_server.docs;
 
 import com.nhnacademy.member_server.dto.request.PointEarnRequest;
 import com.nhnacademy.member_server.dto.request.PointTransactionRequest;

--- a/src/main/java/com/nhnacademy/member_server/docs/PointPolicyAdminSwagger.java
+++ b/src/main/java/com/nhnacademy/member_server/docs/PointPolicyAdminSwagger.java
@@ -1,0 +1,40 @@
+package com.nhnacademy.member_server.docs;
+
+import com.nhnacademy.member_server.dto.request.PointAdminAdjustmentRequest;
+import com.nhnacademy.member_server.dto.request.PointAdminPolicyRequest;
+import com.nhnacademy.member_server.dto.response.PointAdminPolicyResponse;
+import com.nhnacademy.member_server.dto.response.PointTransactionResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "Point Admin API", description = "관리자용 포인트 정책 및 수동 조정 API")
+public interface PointPolicyAdminSwagger {
+
+    @Operation(summary = "포인트 정책 조회", description = "현재 적용 중인 최신 포인트 정책을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
+    ResponseEntity<PointAdminPolicyResponse> getPolicy();
+
+    @Operation(summary = "포인트 정책 변경", description = "새로운 포인트 적립 정책을 등록합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "정책 등록 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 입력값"),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
+    ResponseEntity<Void> updatePolicy(@RequestBody PointAdminPolicyRequest request);
+
+    @Operation(summary = "포인트 수동 조정", description = "관리자가 회원의 포인트를 임의로 지급하거나 차감합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조정 성공 (변경된 잔액 반환)"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 (차감 시 잔액 부족 등)"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 회원"),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
+    ResponseEntity<PointTransactionResponse> manualAdjustment(@RequestBody PointAdminAdjustmentRequest request);
+}

--- a/src/main/java/com/nhnacademy/member_server/docs/PointSwagger.java
+++ b/src/main/java/com/nhnacademy/member_server/docs/PointSwagger.java
@@ -1,4 +1,4 @@
-package com.nhnacademy.member_server.controller;
+package com.nhnacademy.member_server.docs;
 
 import com.nhnacademy.member_server.dto.response.PointBalanceResponse;
 import com.nhnacademy.member_server.dto.response.PointHistoryResponse;

--- a/src/main/java/com/nhnacademy/member_server/dto/request/PointAdminAdjustmentRequest.java
+++ b/src/main/java/com/nhnacademy/member_server/dto/request/PointAdminAdjustmentRequest.java
@@ -1,0 +1,20 @@
+package com.nhnacademy.member_server.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PointAdminAdjustmentRequest {
+    @Schema(description = "조정 대상 회원 ID", example = "1")
+    private Long memberId;
+
+    @Schema(description = "조정 금액 (양수 적립, 음수 차감 처리)", example = "300000")
+    private Long amount;
+
+    @Schema(description = "조정 사유", example = "특별 이벤트 포인트 적립")
+    private String reason;
+}

--- a/src/main/java/com/nhnacademy/member_server/dto/request/PointAdminAdjustmentRequest.java
+++ b/src/main/java/com/nhnacademy/member_server/dto/request/PointAdminAdjustmentRequest.java
@@ -1,6 +1,8 @@
 package com.nhnacademy.member_server.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,11 +12,14 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class PointAdminAdjustmentRequest {
     @Schema(description = "조정 대상 회원 ID", example = "1")
+    @NotNull(message = "회원 ID는 필수입니다")
     private Long memberId;
 
     @Schema(description = "조정 금액 (양수 적립, 음수 차감 처리)", example = "300000")
+    @NotNull(message = "조정 금액은 필수입니다")
     private Long amount;
 
     @Schema(description = "조정 사유", example = "특별 이벤트 포인트 적립")
+    @NotBlank(message = "조정 사유는 필수입니다")
     private String reason;
 }

--- a/src/main/java/com/nhnacademy/member_server/dto/request/PointAdminPolicyRequest.java
+++ b/src/main/java/com/nhnacademy/member_server/dto/request/PointAdminPolicyRequest.java
@@ -1,6 +1,8 @@
 package com.nhnacademy.member_server.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,12 +11,18 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class PointAdminPolicyRequest {
+    @NotNull(message = "회원가입 적립금은 필수입니다")
+    @Min(0)
     @Schema(description = "회원가입 적립금", example = "5000")
     private Integer signupPoint;
 
+    @NotNull(message = "리뷰 적립금은 필수입니다")
+    @Min(0)
     @Schema(description = "일반 리뷰 적립금", example = "200")
     private Integer reviewPoint;
 
-    @Schema(description = "포토 리뷰 적립금", example = "500")
+    @NotNull(message = "사진 리뷰 적립금은 필수입니다")
+    @Min(0)
+    @Schema(description = "사진 리뷰 적립금", example = "500")
     private Integer photoPoint;
 }

--- a/src/main/java/com/nhnacademy/member_server/dto/request/PointAdminPolicyRequest.java
+++ b/src/main/java/com/nhnacademy/member_server/dto/request/PointAdminPolicyRequest.java
@@ -1,0 +1,20 @@
+package com.nhnacademy.member_server.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PointAdminPolicyRequest {
+    @Schema(description = "회원가입 적립금", example = "5000")
+    private Integer signupPoint;
+
+    @Schema(description = "일반 리뷰 적립금", example = "200")
+    private Integer reviewPoint;
+
+    @Schema(description = "포토 리뷰 적립금", example = "500")
+    private Integer photoPoint;
+}

--- a/src/main/java/com/nhnacademy/member_server/dto/request/PointEarnRequest.java
+++ b/src/main/java/com/nhnacademy/member_server/dto/request/PointEarnRequest.java
@@ -2,6 +2,7 @@ package com.nhnacademy.member_server.dto.request;
 
 import com.nhnacademy.member_server.entity.PointEventType;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,9 +11,11 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class PointEarnRequest { //
-    @Schema(description = "포인트 적립 될 유저 아이디", example = "1")
+    @NotNull(message = "회원 아이디는 필수입니다")
+    @Schema(description = "포인트 적립 될 회원 아이디", example = "1")
     private Long memberId;
 
+    @NotNull(message = "적립 타입은 필수입니다")
     @Schema(description = "적립 타입", example = "EARN_ORDER, EARN_REVIEW, EARN_PHOTO_REVIEW, EARN_SIGNUP, EARN_REFUND, EARN_ADMIN, USE_ORDER, USE_ADMIN, REVERT_ORDER")
     private PointEventType eventType;
 

--- a/src/main/java/com/nhnacademy/member_server/dto/request/PointTransactionRequest.java
+++ b/src/main/java/com/nhnacademy/member_server/dto/request/PointTransactionRequest.java
@@ -1,6 +1,7 @@
 package com.nhnacademy.member_server.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,10 +10,15 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class PointTransactionRequest {
-    @Schema(description = "포인트 사용/환불 될 유저 아이디", example = "1")
+    @NotNull(message = "회원 아이디는 필수입니다")
+    @Schema(description = "포인트 사용/환불 될 회원 아이디", example = "1")
     private Long memberId;
+
+    @NotNull(message = "액수는 필수입니다")
     @Schema(description = "포인트 사용/환불 액수", example = "100")
     private Long amount;
+
+    @NotNull(message = "주문 번호는 필수입니다")
     @Schema(description = "포인트 사용/환불 사유에 들어갈 주문 번호", example = "1")
     private Long orderId;
 }

--- a/src/main/java/com/nhnacademy/member_server/dto/response/PointAdminPolicyResponse.java
+++ b/src/main/java/com/nhnacademy/member_server/dto/response/PointAdminPolicyResponse.java
@@ -1,0 +1,22 @@
+package com.nhnacademy.member_server.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PointAdminPolicyResponse {
+    @Schema(description = "회원가입 적립금", example = "5000")
+    private Integer signupPoint;
+
+    @Schema(description = "일반 리뷰 적립금", example = "200")
+    private Integer reviewPoint;
+
+    @Schema(description = "포토 리뷰 적립금", example = "500")
+    private Integer photoPoint;
+}

--- a/src/main/java/com/nhnacademy/member_server/entity/PointPolicy.java
+++ b/src/main/java/com/nhnacademy/member_server/entity/PointPolicy.java
@@ -9,9 +9,9 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.LastModifiedBy;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -20,14 +20,12 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Table(name = "point_policy")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
+@AllArgsConstructor
 public class PointPolicy {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
-    @LastModifiedBy // 엔티티 데이터 수정한 사용자 정보 자동 저장
-    private Long updatedBy;
 
     @LastModifiedDate // 엔티티 데이터 수정시 현재 일시 자동 저장
     @Column(nullable = false)

--- a/src/main/java/com/nhnacademy/member_server/service/PointService.java
+++ b/src/main/java/com/nhnacademy/member_server/service/PointService.java
@@ -1,7 +1,10 @@
 package com.nhnacademy.member_server.service;
 
+import com.nhnacademy.member_server.dto.request.PointAdminAdjustmentRequest;
+import com.nhnacademy.member_server.dto.request.PointAdminPolicyRequest;
 import com.nhnacademy.member_server.dto.request.PointEarnRequest;
 import com.nhnacademy.member_server.dto.request.PointTransactionRequest;
+import com.nhnacademy.member_server.dto.response.PointAdminPolicyResponse;
 import com.nhnacademy.member_server.dto.response.PointBalanceResponse;
 import com.nhnacademy.member_server.dto.response.PointHistoryResponse;
 import org.springframework.data.domain.Page;
@@ -13,4 +16,7 @@ public interface PointService {
     Long revertPoint(PointTransactionRequest requestDto);
     PointBalanceResponse getBalance(Long memberId);
     Page<PointHistoryResponse> getHistory(Long memberId, Pageable pageable);
+    PointAdminPolicyResponse getRecentPolicy();
+    void updatePolicy(PointAdminPolicyRequest requestDto);
+    Long adjustmentMemberPoint(PointAdminAdjustmentRequest request);
 }

--- a/src/main/java/com/nhnacademy/member_server/service/impl/PointServiceImpl.java
+++ b/src/main/java/com/nhnacademy/member_server/service/impl/PointServiceImpl.java
@@ -42,7 +42,7 @@ public class PointServiceImpl implements PointService {
     @Override
     public Long earnPoint(PointEarnRequest requestDto){
         Member member = memberRepository.findByIdForUpdate(requestDto.getMemberId()).orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND));
-        long pointToEarn = 0;
+        long pointToEarn;
         String description = requestDto.getEventType().getDescription();
         Long orderIdToSave = null;
 
@@ -213,6 +213,10 @@ public class PointServiceImpl implements PointService {
         Member member = memberRepository.findByIdForUpdate(request.getMemberId()).orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
 
         long amount = request.getAmount();
+        if (amount == 0) {
+            throw new BusinessException(INVALID_INPUT_VALUE);
+        }
+
         PointEventType eventType;
 
         if (amount > 0) {

--- a/src/main/java/com/nhnacademy/member_server/service/impl/PointServiceImpl.java
+++ b/src/main/java/com/nhnacademy/member_server/service/impl/PointServiceImpl.java
@@ -6,8 +6,11 @@ import static com.nhnacademy.member_server.exception.ErrorCode.POINT_NOT_ENOUGH;
 import static com.nhnacademy.member_server.exception.ErrorCode.POINT_NOT_ORDER_ID;
 import static com.nhnacademy.member_server.exception.ErrorCode.POINT_NOT_POLICY;
 
+import com.nhnacademy.member_server.dto.request.PointAdminAdjustmentRequest;
+import com.nhnacademy.member_server.dto.request.PointAdminPolicyRequest;
 import com.nhnacademy.member_server.dto.request.PointEarnRequest;
 import com.nhnacademy.member_server.dto.request.PointTransactionRequest;
+import com.nhnacademy.member_server.dto.response.PointAdminPolicyResponse;
 import com.nhnacademy.member_server.dto.response.PointBalanceResponse;
 import com.nhnacademy.member_server.dto.response.PointHistoryResponse;
 import com.nhnacademy.member_server.entity.Member;
@@ -15,11 +18,13 @@ import com.nhnacademy.member_server.entity.PointEventType;
 import com.nhnacademy.member_server.entity.PointHistory;
 import com.nhnacademy.member_server.entity.PointPolicy;
 import com.nhnacademy.member_server.exception.BusinessException;
+import com.nhnacademy.member_server.exception.ErrorCode;
 import com.nhnacademy.member_server.repository.MemberRepository;
 import com.nhnacademy.member_server.repository.PointHistoryRepository;
 import com.nhnacademy.member_server.repository.PointPolicyRepository;
 import com.nhnacademy.member_server.service.PointService;
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -175,6 +180,67 @@ public class PointServiceImpl implements PointService {
         ));
     }
 
+    // 관리자용 메서드
+    @Override
+    @Transactional(readOnly = true)
+    public PointAdminPolicyResponse getRecentPolicy(){
+        PointPolicy policy = pointPolicyRepository.findTopByOrderByUpdatedAtDesc();
+
+        if(policy == null){
+            throw new BusinessException(ErrorCode.POINT_NOT_POLICY);
+        }
+
+        return PointAdminPolicyResponse.builder()
+                .signupPoint(policy.getSignupPoint())
+                .reviewPoint(policy.getReviewPoint())
+                .photoPoint(policy.getPhotoPoint())
+                .build();
+    }
+
+    @Override // 새 정책 insert
+    public void updatePolicy(PointAdminPolicyRequest requestDto){
+        pointPolicyRepository.save(new PointPolicy(
+                null,
+                LocalDateTime.now(),
+                requestDto.getSignupPoint(),
+                requestDto.getReviewPoint(),
+                requestDto.getPhotoPoint()
+        ));
+    }
+
+    @Override
+    public Long adjustmentMemberPoint(PointAdminAdjustmentRequest request) {
+        Member member = memberRepository.findByIdForUpdate(request.getMemberId()).orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+
+        long amount = request.getAmount();
+        PointEventType eventType;
+
+        if (amount > 0) {
+            eventType = PointEventType.EARN_ADMIN;
+        } else {
+            // 사용자 포인트 음수 안되게 막기
+            if (member.getCurrentPoint() < Math.abs(amount)) {
+                throw new BusinessException(ErrorCode.POINT_NOT_ENOUGH);
+            }
+            eventType = PointEventType.USE_ADMIN;
+        }
+
+        long newBalance = member.getCurrentPoint() + amount;
+        member.setCurrentPoint(newBalance);
+
+        String description = String.format("%s (사유: %s)", eventType.getDescription(), request.getReason());
+
+        pointHistoryRepository.save(new PointHistory(
+                null,
+                member,
+                amount,
+                description,
+                eventType,
+                newBalance
+        ));
+
+        return newBalance;
+    }
 
     // 검증 메서드
     private void validateOrderRequest(PointEarnRequest requestDto) {

--- a/src/test/java/com/nhnacademy/member_server/service/PointConcurrencyTest.java
+++ b/src/test/java/com/nhnacademy/member_server/service/PointConcurrencyTest.java
@@ -68,6 +68,7 @@ class PointConcurrencyTest {
         }
 
         latch.await(); // 0이 되기 전까지 block
+        executor.shutdown();
 
         Member member = memberRepository.findById(memberId).orElseThrow();
         assertThat(member.getCurrentPoint()).isEqualTo(0L);


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #5

## 📝작업 내용

> 관리자 정책 조회 API 구현. 정책 수정 API 구현 (일단 회원가입, 리뷰, 포토리뷰만), 사용자의 포인트를 강제 조정하는 API 구현, 업데이트한 관리자 이름 컬럼 삭제 및 코드에 반영


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 관리자용 포인트 정책 조회 및 관리 기능 추가
  * 관리자의 수동 포인트 조정(적립/차감) 기능 추가 (잔액 검증 포함)
  * 포인트 정책(가입, 리뷰, 사진)의 설정 및 업데이트 기능 지원

* **개선사항**
  * API 요청 데이터 검증 강화
  * API 문서화 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->