### PR TITLE
✨ feat: TCC용 포인트 api 구현

### DIFF
--- a/src/main/java/com/nhnacademy/member_server/controller/PointTccController.java
+++ b/src/main/java/com/nhnacademy/member_server/controller/PointTccController.java
@@ -1,0 +1,39 @@
+package com.nhnacademy.member_server.controller;
+
+import com.nhnacademy.member_server.service.PointService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/members")
+public class PointTccController {
+
+    private final PointService pointService;
+
+    @PostMapping("/{userId}/point/reserve")
+    public void reservePoint(@PathVariable("userId") Long userId, @RequestParam("amount") Long amount, @RequestParam("orderId") Long orderId) {
+        pointService.reservePoint(userId, amount, orderId);
+    }
+
+    @PostMapping("/{userId}/point/confirm")
+    public void confirmPoint(@PathVariable("userId") Long userId, @RequestParam("amount") Long amount, @RequestParam("orderId") Long orderId) {
+        pointService.confirmPoint(userId, amount, orderId);
+    }
+
+    @PostMapping("/{userId}/point/cancel")
+    public void cancelPoint(@PathVariable("userId") Long userId, @RequestParam("amount") Long amount, @RequestParam("orderId") Long orderId) {
+        pointService.cancelPoint(userId, amount, orderId);
+    }
+
+    // MemberClient.getPointBalance
+    @GetMapping("/{userId}/point-balance")
+    public Integer getPointBalance(@PathVariable("userId") Long userId) {
+        return pointService.getBalance(userId).getCurrentPoint().intValue();
+    }
+}

--- a/src/main/java/com/nhnacademy/member_server/controller/PointTccController.java
+++ b/src/main/java/com/nhnacademy/member_server/controller/PointTccController.java
@@ -16,24 +16,24 @@ public class PointTccController {
 
     private final PointService pointService;
 
-    @PostMapping("/{userId}/point/reserve")
-    public void reservePoint(@PathVariable("userId") Long userId, @RequestParam("amount") Long amount, @RequestParam("orderId") Long orderId) {
-        pointService.reservePoint(userId, amount, orderId);
+    @PostMapping("/{memberId}/point/reserve")
+    public void reservePoint(@PathVariable("memberId") Long memberId, @RequestParam("amount") Long amount, @RequestParam("orderId") Long orderId) {
+        pointService.reservePoint(memberId, amount, orderId);
     }
 
-    @PostMapping("/{userId}/point/confirm")
-    public void confirmPoint(@PathVariable("userId") Long userId, @RequestParam("amount") Long amount, @RequestParam("orderId") Long orderId) {
-        pointService.confirmPoint(userId, amount, orderId);
+    @PostMapping("/{memberId}/point/confirm")
+    public void confirmPoint(@PathVariable("memberId") Long memberId, @RequestParam("amount") Long amount, @RequestParam("orderId") Long orderId) {
+        pointService.confirmPoint(memberId, amount, orderId);
     }
 
-    @PostMapping("/{userId}/point/cancel")
-    public void cancelPoint(@PathVariable("userId") Long userId, @RequestParam("amount") Long amount, @RequestParam("orderId") Long orderId) {
-        pointService.cancelPoint(userId, amount, orderId);
+    @PostMapping("/{memberId}/point/cancel")
+    public void cancelPoint(@PathVariable("memberId") Long memberId, @RequestParam("amount") Long amount, @RequestParam("orderId") Long orderId) {
+        pointService.cancelPoint(memberId, amount, orderId);
     }
 
     // MemberClient.getPointBalance
-    @GetMapping("/{userId}/point-balance")
-    public Integer getPointBalance(@PathVariable("userId") Long userId) {
-        return pointService.getBalance(userId).getCurrentPoint().intValue();
+    @GetMapping("/{memberId}/point-balance")
+    public Integer getPointBalance(@PathVariable("memberId") Long memberId) {
+        return pointService.getBalance(memberId).getCurrentPoint().intValue();
     }
 }

--- a/src/main/java/com/nhnacademy/member_server/entity/PointHistory.java
+++ b/src/main/java/com/nhnacademy/member_server/entity/PointHistory.java
@@ -56,13 +56,22 @@ public class PointHistory {
     @Column(nullable = false)
     private Long pointBalance;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private PointStatus status; // RESERVED, CONFIRMED, CANCELED
+
     @Builder
-    public PointHistory(Long orderId, Member member, Long amount, String description, PointEventType pointEventType, Long pointBalance) {
+    public PointHistory(Long orderId, Member member, Long amount, String description, PointEventType pointEventType, Long pointBalance, PointStatus status) {
         this.orderId = orderId;
         this.member = member;
         this.amount = amount;
         this.description = description;
         this.pointEventType = pointEventType;
         this.pointBalance = pointBalance;
+        this.status = (status != null) ? status : PointStatus.CONFIRMED;
+    }
+
+    public void updateStatus(PointStatus status) {
+        this.status = status;
     }
 }

--- a/src/main/java/com/nhnacademy/member_server/entity/PointStatus.java
+++ b/src/main/java/com/nhnacademy/member_server/entity/PointStatus.java
@@ -1,0 +1,7 @@
+package com.nhnacademy.member_server.entity;
+
+public enum PointStatus {
+    RESERVED,   // 사용 예약 (차감 대기)
+    CONFIRMED,  // 사용 확정
+    CANCELED    // 취소 (환불됨)
+}

--- a/src/main/java/com/nhnacademy/member_server/repository/PointHistoryRepository.java
+++ b/src/main/java/com/nhnacademy/member_server/repository/PointHistoryRepository.java
@@ -1,5 +1,6 @@
 package com.nhnacademy.member_server.repository;
 
+import com.nhnacademy.member_server.entity.PointEventType;
 import com.nhnacademy.member_server.entity.PointHistory;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -16,4 +17,7 @@ public interface PointHistoryRepository extends JpaRepository<PointHistory, Long
             "AND ph.amount > 0 " +
             "AND ph.pointEventType != 'EARN_REFUND'")
     Long sumEarnedPoints(@Param("memberId") Long memberId);
+
+    // 멱등성 검사용
+    boolean existsByOrderIdAndEventType(Long orderId, PointEventType eventType);
 }

--- a/src/main/java/com/nhnacademy/member_server/repository/PointHistoryRepository.java
+++ b/src/main/java/com/nhnacademy/member_server/repository/PointHistoryRepository.java
@@ -2,6 +2,7 @@ package com.nhnacademy.member_server.repository;
 
 import com.nhnacademy.member_server.entity.PointEventType;
 import com.nhnacademy.member_server.entity.PointHistory;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -19,5 +20,8 @@ public interface PointHistoryRepository extends JpaRepository<PointHistory, Long
     Long sumEarnedPoints(@Param("memberId") Long memberId);
 
     // 멱등성 검사용
-    boolean existsByOrderIdAndEventType(Long orderId, PointEventType eventType);
+    boolean existsByOrderIdAndPointEventType(Long orderId, PointEventType eventType);
+
+    // 상태 변경을 위한 단건 조회용
+    Optional<PointHistory> findByOrderIdAndPointEventType(Long orderId, PointEventType pointEventType);
 }

--- a/src/main/java/com/nhnacademy/member_server/service/PointService.java
+++ b/src/main/java/com/nhnacademy/member_server/service/PointService.java
@@ -19,4 +19,8 @@ public interface PointService {
     PointAdminPolicyResponse getRecentPolicy();
     void updatePolicy(PointAdminPolicyRequest requestDto);
     Long adjustmentMemberPoint(PointAdminAdjustmentRequest requestDto);
+
+    void reservePoint(Long memberId, Long amount, Long orderId);
+    void confirmPoint(Long memberId, Long amount, Long orderId);
+    void cancelPoint(Long memberId, Long amount, Long orderId);
 }

--- a/src/main/java/com/nhnacademy/member_server/service/impl/PointServiceImpl.java
+++ b/src/main/java/com/nhnacademy/member_server/service/impl/PointServiceImpl.java
@@ -25,6 +25,7 @@ import com.nhnacademy.member_server.repository.PointPolicyRepository;
 import com.nhnacademy.member_server.service.PointService;
 import java.math.BigDecimal;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -33,6 +34,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 @Transactional
+@Slf4j
 public class PointServiceImpl implements PointService {
     private final MemberRepository memberRepository;
     private final PointHistoryRepository pointHistoryRepository;
@@ -242,6 +244,28 @@ public class PointServiceImpl implements PointService {
         ));
 
         return newBalance;
+    }
+
+    @Override
+    public void reservePoint(Long memberId, Long amount, Long orderId) {
+        // TCC - Try: 포인트 선점 (실제 차감 진행)
+        PointTransactionRequest request = new PointTransactionRequest(memberId, amount, orderId);
+        usePoint(request); // 잔액 부족 시 예외 발생 -> 주문 서버가 감지하고 롤백함
+        log.info("TCC Reserve(차감) 완료: memberId={}, amount={}, orderId={}", memberId, amount, orderId);
+    }
+
+    @Override
+    public void confirmPoint(Long memberId, Long amount, Long orderId) {
+        // TCC - Confirm: 확정
+        log.info("TCC Confirm(확정) 완료: memberId={}, amount={}, orderId={}", memberId, amount, orderId);
+    }
+
+    @Override
+    public void cancelPoint(Long memberId, Long amount, Long orderId) {
+        // TCC - Cancel: 보상 트랜잭션 (환불)
+        PointTransactionRequest request = new PointTransactionRequest(memberId, amount, orderId);
+        revertPoint(request);
+        log.info("TCC Cancel(환불) 완료: memberId={}, amount={}, orderId={}", memberId, amount, orderId);
     }
 
     // 검증 메서드

--- a/src/main/java/com/nhnacademy/member_server/service/impl/PointServiceImpl.java
+++ b/src/main/java/com/nhnacademy/member_server/service/impl/PointServiceImpl.java
@@ -248,24 +248,49 @@ public class PointServiceImpl implements PointService {
 
     @Override
     public void reservePoint(Long memberId, Long amount, Long orderId) {
-        // TCC - Try: 포인트 선점 (실제 차감 진행)
+        log.info("TCC Reserve 요청: memberId={}, amount={}, orderId={}", memberId, amount, orderId);
+
+        if (pointHistoryRepository.existsByOrderIdAndEventType(orderId, PointEventType.USE_ORDER)) {
+            log.warn("이미 처리된 예약 요청입니다. (Idempotency Check Passed): orderId={}", orderId);
+            return;
+        }
+
         PointTransactionRequest request = new PointTransactionRequest(memberId, amount, orderId);
-        usePoint(request); // 잔액 부족 시 예외 발생 -> 주문 서버가 감지하고 롤백함
-        log.info("TCC Reserve(차감) 완료: memberId={}, amount={}, orderId={}", memberId, amount, orderId);
+        usePoint(request);
+
+        log.info("TCC Reserve(차감) 완료: memberId={}, amount={}", memberId, amount);
     }
 
     @Override
     public void confirmPoint(Long memberId, Long amount, Long orderId) {
-        // TCC - Confirm: 확정
-        log.info("TCC Confirm(확정) 완료: memberId={}, amount={}, orderId={}", memberId, amount, orderId);
+
+        if (!pointHistoryRepository.existsByOrderIdAndEventType(orderId, PointEventType.USE_ORDER)) {
+            log.error("예약(차감) 내역이 존재하지 않는 주문에 대한 확정 요청입니다. orderId={}", orderId);
+
+            throw new BusinessException(ErrorCode.POINT_NOT_FOUND);
+        }
+
+        log.info("TCC Confirm(확정) 완료: memberId={}, orderId={}", memberId, orderId);
     }
 
     @Override
     public void cancelPoint(Long memberId, Long amount, Long orderId) {
-        // TCC - Cancel: 보상 트랜잭션 (환불)
+        log.info("TCC Cancel 요청: memberId={}, amount={}, orderId={}", memberId, amount, orderId);
+
+        if (pointHistoryRepository.existsByOrderIdAndEventType(orderId, PointEventType.REVERT_ORDER)) {
+            log.warn("이미 환불 처리된 요청입니다.: orderId={}", orderId);
+            return;
+        }
+        
+        if (!pointHistoryRepository.existsByOrderIdAndEventType(orderId, PointEventType.USE_ORDER)) {
+            log.warn("차감 내역이 없어 환불을 수행하지 않습니다.: orderId={}", orderId);
+            return;
+        }
+
         PointTransactionRequest request = new PointTransactionRequest(memberId, amount, orderId);
         revertPoint(request);
-        log.info("TCC Cancel(환불) 완료: memberId={}, amount={}, orderId={}", memberId, amount, orderId);
+
+        log.info("TCC Cancel(환불) 완료: memberId={}, orderId={}", memberId, orderId);
     }
 
     // 검증 메서드

--- a/src/main/java/com/nhnacademy/member_server/service/impl/PointServiceImpl.java
+++ b/src/main/java/com/nhnacademy/member_server/service/impl/PointServiceImpl.java
@@ -226,61 +226,52 @@ public class PointServiceImpl implements PointService {
         return newBalance;
     }
 
-    // [수정] TCC Reserve: 포인트 차감 후 'RESERVED' 상태로 저장
     @Override
     public void reservePoint(Long memberId, Long amount, Long orderId) {
         log.info("TCC Reserve 요청: memberId={}, amount={}, orderId={}", memberId, amount, orderId);
 
-        // 멱등성 검사
         if (pointHistoryRepository.existsByOrderIdAndPointEventType(orderId, PointEventType.USE_ORDER)) {
             log.warn("이미 처리된 예약 요청입니다.: orderId={}", orderId);
             return;
         }
 
         PointTransactionRequest request = new PointTransactionRequest(memberId, amount, orderId);
-        // 여기서 핵심! 상태를 RESERVED로 넘김
+
         processUsePoint(request, PointStatus.RESERVED);
 
         log.info("TCC Reserve(차감/예약) 완료: memberId={}, amount={}", memberId, amount);
     }
 
-    // [수정] TCC Confirm: 'RESERVED' 상태를 'CONFIRMED'로 변경
     @Override
     public void confirmPoint(Long memberId, Long amount, Long orderId) {
-        // 1. 예약 내역 조회
+
         PointHistory history = pointHistoryRepository.findByOrderIdAndPointEventType(orderId, PointEventType.USE_ORDER)
                 .orElseThrow(() -> new BusinessException(ErrorCode.POINT_NOT_FOUND));
 
-        // 2. 상태 검증
         if (history.getStatus() == PointStatus.CONFIRMED) {
             log.info("이미 확정된 주문입니다: orderId={}", orderId);
             return;
         }
 
         if (history.getStatus() != PointStatus.RESERVED) {
-            // CANCELED 상태 등에서 Confirm이 들어오면 에러 혹은 무시
             throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE); // 적절한 에러코드 사용
         }
 
-        // 3. 상태 변경 (DB 업데이트)
         history.updateStatus(PointStatus.CONFIRMED);
 
         log.info("TCC Confirm(확정) 완료: memberId={}, orderId={}", memberId, orderId);
     }
 
-    // [수정] TCC Cancel: 'RESERVED' 상태일 때만 취소/환불 진행
     @Override
     public void cancelPoint(Long memberId, Long amount, Long orderId) {
         log.info("TCC Cancel 요청: memberId={}, orderId={}", memberId, orderId);
 
-        // 1. 예약 내역 조회
         PointHistory history = pointHistoryRepository.findByOrderIdAndPointEventType(orderId, PointEventType.USE_ORDER)
                 .orElseThrow(() -> {
                     log.warn("취소할 내역이 없습니다. orderId={}", orderId);
                     return new BusinessException(ErrorCode.POINT_NOT_FOUND);
                 });
 
-        // 2. 상태 검증 (CodeRabbit 지적 사항: Reserve된 것만 취소해야 함)
         if (history.getStatus() == PointStatus.CANCELED) {
             log.warn("이미 취소된 주문입니다: orderId={}", orderId);
             return;
@@ -288,21 +279,17 @@ public class PointServiceImpl implements PointService {
 
         if (history.getStatus() == PointStatus.CONFIRMED) {
             log.error("이미 확정(Confirm)된 주문은 TCC Cancel로 취소할 수 없습니다. (별도 반품 로직 필요): orderId={}", orderId);
-            // 비즈니스 로직에 따라 여기서 에러를 뱉거나, return 하거나 선택
             return;
         }
 
-        // 3. 환불 로직 수행 (포인트 되돌리기)
-        PointTransactionRequest request = new PointTransactionRequest(memberId, amount, orderId);
-        revertPoint(request); // 이 메서드는 'REVERT_ORDER' 타입의 히스토리를 새로 쌓습니다 (Status는 기본값 CONFIRMED)
-
-        // 4. 원본 예약 내역 상태를 CANCELED로 변경
         history.updateStatus(PointStatus.CANCELED);
+
+        PointTransactionRequest request = new PointTransactionRequest(memberId, amount, orderId);
+
+        revertPoint(request);
 
         log.info("TCC Cancel(환불) 완료: memberId={}, orderId={}", memberId, orderId);
     }
-
-
 
     private Long processUsePoint(PointTransactionRequest requestDto, PointStatus status) {
         validateTransactionRequest(requestDto);

--- a/src/main/java/com/nhnacademy/member_server/service/impl/PointServiceImpl.java
+++ b/src/main/java/com/nhnacademy/member_server/service/impl/PointServiceImpl.java
@@ -16,6 +16,7 @@ import com.nhnacademy.member_server.dto.response.PointHistoryResponse;
 import com.nhnacademy.member_server.entity.PointEventType;
 import com.nhnacademy.member_server.entity.PointHistory;
 import com.nhnacademy.member_server.entity.PointPolicy;
+import com.nhnacademy.member_server.entity.PointStatus;
 import com.nhnacademy.member_server.entity.member.Member;
 import com.nhnacademy.member_server.exception.BusinessException;
 import com.nhnacademy.member_server.exception.ErrorCode;
@@ -98,7 +99,8 @@ public class PointServiceImpl implements PointService {
                     pointToEarn,
                     description,
                     requestDto.getEventType(),
-                    newPointBalance
+                    newPointBalance,
+                    PointStatus.CONFIRMED
             ));
             return newPointBalance;
         }
@@ -106,32 +108,8 @@ public class PointServiceImpl implements PointService {
     }
 
     @Override
-    public Long usePoint(PointTransactionRequest requestDto){
-        validateTransactionRequest(requestDto);
-
-        Member member = memberRepository.findByIdForUpdate(requestDto.getMemberId()).orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND));
-
-        long amountUsedPoint = requestDto.getAmount();
-
-        if(member.getCurrentPoint() < amountUsedPoint){
-            throw new BusinessException(POINT_NOT_ENOUGH);
-        }
-
-        // 잔액 차감
-        long newPointBalance = member.getCurrentPoint() - amountUsedPoint;
-        member.setCurrentPoint(newPointBalance);
-
-        String description = String.format("%s (주문번호: %d)",PointEventType.USE_ORDER.getDescription(), requestDto.getOrderId());
-
-        pointHistoryRepository.save(new PointHistory(
-                requestDto.getOrderId(),
-                member,
-                -amountUsedPoint, // 사용 -> 음수저장
-                description,
-                PointEventType.USE_ORDER,
-                newPointBalance
-        ));
-        return newPointBalance;
+    public Long usePoint(PointTransactionRequest requestDto) {
+        return processUsePoint(requestDto, PointStatus.CONFIRMED);
     }
 
     @Override
@@ -154,7 +132,8 @@ public class PointServiceImpl implements PointService {
                 amountRevertedPoint,
                 description,
                 PointEventType.REVERT_ORDER,
-                newPointBalance
+                newPointBalance,
+                PointStatus.CONFIRMED
         ));
         return newPointBalance;
     }
@@ -240,57 +219,119 @@ public class PointServiceImpl implements PointService {
                 amount,
                 description,
                 eventType,
-                newBalance
+                newBalance,
+                PointStatus.CONFIRMED
         ));
 
         return newBalance;
     }
 
+    // [수정] TCC Reserve: 포인트 차감 후 'RESERVED' 상태로 저장
     @Override
     public void reservePoint(Long memberId, Long amount, Long orderId) {
         log.info("TCC Reserve 요청: memberId={}, amount={}, orderId={}", memberId, amount, orderId);
 
-        if (pointHistoryRepository.existsByOrderIdAndEventType(orderId, PointEventType.USE_ORDER)) {
-            log.warn("이미 처리된 예약 요청입니다. (Idempotency Check Passed): orderId={}", orderId);
+        // 멱등성 검사
+        if (pointHistoryRepository.existsByOrderIdAndPointEventType(orderId, PointEventType.USE_ORDER)) {
+            log.warn("이미 처리된 예약 요청입니다.: orderId={}", orderId);
             return;
         }
 
         PointTransactionRequest request = new PointTransactionRequest(memberId, amount, orderId);
-        usePoint(request);
+        // 여기서 핵심! 상태를 RESERVED로 넘김
+        processUsePoint(request, PointStatus.RESERVED);
 
-        log.info("TCC Reserve(차감) 완료: memberId={}, amount={}", memberId, amount);
+        log.info("TCC Reserve(차감/예약) 완료: memberId={}, amount={}", memberId, amount);
     }
 
+    // [수정] TCC Confirm: 'RESERVED' 상태를 'CONFIRMED'로 변경
     @Override
     public void confirmPoint(Long memberId, Long amount, Long orderId) {
+        // 1. 예약 내역 조회
+        PointHistory history = pointHistoryRepository.findByOrderIdAndPointEventType(orderId, PointEventType.USE_ORDER)
+                .orElseThrow(() -> new BusinessException(ErrorCode.POINT_NOT_FOUND));
 
-        if (!pointHistoryRepository.existsByOrderIdAndEventType(orderId, PointEventType.USE_ORDER)) {
-            log.error("예약(차감) 내역이 존재하지 않는 주문에 대한 확정 요청입니다. orderId={}", orderId);
-
-            throw new BusinessException(ErrorCode.POINT_NOT_FOUND);
+        // 2. 상태 검증
+        if (history.getStatus() == PointStatus.CONFIRMED) {
+            log.info("이미 확정된 주문입니다: orderId={}", orderId);
+            return;
         }
+
+        if (history.getStatus() != PointStatus.RESERVED) {
+            // CANCELED 상태 등에서 Confirm이 들어오면 에러 혹은 무시
+            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE); // 적절한 에러코드 사용
+        }
+
+        // 3. 상태 변경 (DB 업데이트)
+        history.updateStatus(PointStatus.CONFIRMED);
 
         log.info("TCC Confirm(확정) 완료: memberId={}, orderId={}", memberId, orderId);
     }
 
+    // [수정] TCC Cancel: 'RESERVED' 상태일 때만 취소/환불 진행
     @Override
     public void cancelPoint(Long memberId, Long amount, Long orderId) {
-        log.info("TCC Cancel 요청: memberId={}, amount={}, orderId={}", memberId, amount, orderId);
+        log.info("TCC Cancel 요청: memberId={}, orderId={}", memberId, orderId);
 
-        if (pointHistoryRepository.existsByOrderIdAndEventType(orderId, PointEventType.REVERT_ORDER)) {
-            log.warn("이미 환불 처리된 요청입니다.: orderId={}", orderId);
+        // 1. 예약 내역 조회
+        PointHistory history = pointHistoryRepository.findByOrderIdAndPointEventType(orderId, PointEventType.USE_ORDER)
+                .orElseThrow(() -> {
+                    log.warn("취소할 내역이 없습니다. orderId={}", orderId);
+                    return new BusinessException(ErrorCode.POINT_NOT_FOUND);
+                });
+
+        // 2. 상태 검증 (CodeRabbit 지적 사항: Reserve된 것만 취소해야 함)
+        if (history.getStatus() == PointStatus.CANCELED) {
+            log.warn("이미 취소된 주문입니다: orderId={}", orderId);
             return;
         }
-        
-        if (!pointHistoryRepository.existsByOrderIdAndEventType(orderId, PointEventType.USE_ORDER)) {
-            log.warn("차감 내역이 없어 환불을 수행하지 않습니다.: orderId={}", orderId);
+
+        if (history.getStatus() == PointStatus.CONFIRMED) {
+            log.error("이미 확정(Confirm)된 주문은 TCC Cancel로 취소할 수 없습니다. (별도 반품 로직 필요): orderId={}", orderId);
+            // 비즈니스 로직에 따라 여기서 에러를 뱉거나, return 하거나 선택
             return;
         }
 
+        // 3. 환불 로직 수행 (포인트 되돌리기)
         PointTransactionRequest request = new PointTransactionRequest(memberId, amount, orderId);
-        revertPoint(request);
+        revertPoint(request); // 이 메서드는 'REVERT_ORDER' 타입의 히스토리를 새로 쌓습니다 (Status는 기본값 CONFIRMED)
+
+        // 4. 원본 예약 내역 상태를 CANCELED로 변경
+        history.updateStatus(PointStatus.CANCELED);
 
         log.info("TCC Cancel(환불) 완료: memberId={}, orderId={}", memberId, orderId);
+    }
+
+
+
+    private Long processUsePoint(PointTransactionRequest requestDto, PointStatus status) {
+        validateTransactionRequest(requestDto);
+        Member member = memberRepository.findByIdForUpdate(requestDto.getMemberId())
+                .orElseThrow(() -> new BusinessException(MEMBER_NOT_FOUND));
+
+        long amountUsedPoint = requestDto.getAmount();
+        if (member.getCurrentPoint() < amountUsedPoint) {
+            throw new BusinessException(POINT_NOT_ENOUGH);
+        }
+
+        // 잔액 차감
+        long newPointBalance = member.getCurrentPoint() - amountUsedPoint;
+        member.setCurrentPoint(newPointBalance);
+
+        String description = String.format("%s (주문번호: %d)", PointEventType.USE_ORDER.getDescription(), requestDto.getOrderId());
+
+        // History 저장 시 전달받은 Status 사용
+        pointHistoryRepository.save(new PointHistory(
+                requestDto.getOrderId(),
+                member,
+                -amountUsedPoint,
+                description,
+                PointEventType.USE_ORDER,
+                newPointBalance,
+                status // RESERVED or CONFIRMED
+        ));
+
+        return newPointBalance;
     }
 
     // 검증 메서드


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #102 

## 📝작업 내용

> TCC용 포인트 api 구현


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 포인트 예약·확정·취소 API 추가 — 포인트를 사전 예약하고 확정하거나 취소할 수 있습니다.
  * 포인트 잔액 조회 API 추가 — 현재 보유 포인트를 확인할 수 있습니다.

* **개선**
  * 예약→확정→취소(TCC 유사) 흐름 도입으로 포인트 처리의 신뢰성·일관성 향상.
  * 거래 이력에 상태 관리가 추가되어 상태별 추적 및 idempotency 강화.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->