### PR TITLE
fix: queue이름 변경 및 pom.xml 수정

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,18 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.zaxxer</groupId>
+                    <artifactId>HikariCP</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-dbcp2</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-redis</artifactId>

--- a/src/main/java/com/nhnacademy/member_server/service/impl/member/AuthServiceImpl.java
+++ b/src/main/java/com/nhnacademy/member_server/service/impl/member/AuthServiceImpl.java
@@ -124,7 +124,7 @@ public class AuthServiceImpl implements AuthService {
 
         try {
             CouponIssueMessage message = new CouponIssueMessage(savedMember.getId());
-            rabbitTemplate.convertAndSend("coupon-welcome-queue", message);
+            rabbitTemplate.convertAndSend("high-five-coupon-welcome-queue", message);
             log.info("신규 회원({}) 웰컴 쿠폰 지급 메시지 발행 완료", savedMember.getId());
         } catch (Exception e) {
             log.error("웰컴 쿠폰 메시지 발행 실패: {}", e.getMessage());
@@ -274,7 +274,7 @@ public class AuthServiceImpl implements AuthService {
 
         try {
             CouponIssueMessage message = new CouponIssueMessage(savedMember.getId());
-            rabbitTemplate.convertAndSend("coupon-welcome-queue", message);
+            rabbitTemplate.convertAndSend("high-five-coupon-welcome-queue", message);
             log.info("신규 회원({}) 웰컴 쿠폰 지급 메시지 발행 완료", savedMember.getId());
         }catch (Exception e){
             log.error("웰컴 쿠폰 메시지 발행 실패: {}", e.getMessage());

--- a/src/test/java/com/nhnacademy/member_server/service/impl/member/AuthServiceImplTest.java
+++ b/src/test/java/com/nhnacademy/member_server/service/impl/member/AuthServiceImplTest.java
@@ -98,7 +98,7 @@ class AuthServiceImplTest {
 
 
         verify(memberRepository).save(any(Member.class));
-        verify(rabbitTemplate).convertAndSend(eq("coupon-welcome-queue"), any(Object.class));
+        verify(rabbitTemplate).convertAndSend(eq("high-five-coupon-welcome-queue"), any(Object.class));
     }
 
     @Test


### PR DESCRIPTION
## #️⃣연관된 이슈

> 

## 📝작업 내용

> queue이름 변경 및 pom.xml 수정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **유지보수**
  * 환영 쿠폰 발송 관련 내부 메시지 경로의 명칭을 업데이트하여 메시지 흐름을 정비했습니다. 가입(일반/소셜) 시 쿠폰 발송 동작은 기존과 동일하게 유지됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->